### PR TITLE
Fix information leakage from on-disk cache

### DIFF
--- a/lib/processes.js
+++ b/lib/processes.js
@@ -466,8 +466,9 @@ function cache_details(local_name, details, callback) {
     init_working_dirs([details], function(err) {
         if (err) return callback(err);
         var folder = module_working_dir(local_name),
-            cache  = path.join(folder, cache_name);
-        fs.writeFile(cache, JSON.stringify(details, 3), callback);
+            cache  = path.join(folder, cache_name),
+            options = { mode: 0600, encoding: 'utf8' };
+        fs.writeFile(cache, JSON.stringify(details, 3), options, callback);
     });
 }
 


### PR DESCRIPTION
If permissions for the top-level `working_dir` are not restrictive enough, credentials stored in Gardener's `.details` files may be visible to users with local system accounts. Set permissions explicitly in `fs.writeFile` so that this information leakage isn't possible. Existing files may have to have a `chmod` performed manually.