### PR TITLE
Resolve #29: Be compatible with NPM v3

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -38,7 +38,7 @@ exports.install = function(url, working_dir, update, callback) {
         utils.scrub_auth_from_string(url)
     );
 
-    npm.commands.install(working_dir, url, function (err, data) {
+    npm.commands.install(working_dir, [ url ], function (err, data) {
 
         // remove the npm listener
         npmout.removeListener('log', msgner);


### PR DESCRIPTION
This much-simpler-than-expected compatibility fix tested out okay
on both NPM v3.8.9 and NPM v2.5.1. No runtime check required.