### PR TITLE
Check if module_name has a value before trying to access it.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,7 +17,10 @@ exports.fromBase64 = function(str) {
 
 exports.is_tgz = function(module_name) {
     var suffix = '.tgz';
-    return (module_name.indexOf(suffix, module_name.length - suffix.length) !== -1);
+    if(module_name) {
+        return (module_name.indexOf(suffix, module_name.length - suffix.length) !== -1);
+    }
+    return false;
 };
 
 


### PR DESCRIPTION
Addressing a bug caused by not checking that `module_name` has value before trying to use it.